### PR TITLE
Fix ecs Container Insights V2 and Cognito Domain lock in consecutive redeployment

### DIFF
--- a/source/bin/app.ts
+++ b/source/bin/app.ts
@@ -14,6 +14,12 @@ const resourceSuffix = app.node.addr
   .toLowerCase()
   .replace(/[^a-z0-9-]/g, "");
 
+const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+  let domainSuffix = "";
+  for (let i = 0; i < 8; i++) {
+    domainSuffix += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+
 // Get context values for existing VPC if provided
 const existingVpcId = app.node.tryGetContext("existingVpcId");
 const publicSubnetIds = app.node.tryGetContext("publicSubnetIds")?.split(",");
@@ -38,6 +44,7 @@ const securityStack = new SecurityStack(app, "MCP-Security", {
   },
   vpc: vpcStack.vpc,
   resourceSuffix,
+  domainSuffix: domainSuffix,
 });
 
 // Get the target region (where the MCP server stack will be deployed)
@@ -65,6 +72,7 @@ const serverStack = new MCPServerStack(app, "MCP-Server", {
   cognitoUserPool: securityStack.userPool,
   userPoolClientId: securityStack.appClientUser.userPoolClientId,
   userPoolClientSecret: securityStack.appClientUser.userPoolClientSecret,
+  domainSuffix: domainSuffix,
 });
 serverStack.addDependency(cloudFrontWafStack);
 

--- a/source/lib/stacks/mcp-server-stack.ts
+++ b/source/lib/stacks/mcp-server-stack.ts
@@ -56,7 +56,7 @@ export class MCPServerStack extends cdk.Stack {
     // Create shared ECS cluster for all MCP servers
     this.cluster = new ecs.Cluster(this, "MCPCluster", {
       vpc: props.vpc,
-      containerInsights: true,
+      containerInsightsV2: ecs.ContainerInsights.ENHANCED
     });
 
     // Create context parameter for optional certificate ARN and custom domain

--- a/source/lib/stacks/mcp-server-stack.ts
+++ b/source/lib/stacks/mcp-server-stack.ts
@@ -59,6 +59,15 @@ export class MCPServerStack extends cdk.Stack {
       containerInsightsV2: ecs.ContainerInsights.ENHANCED
     });
 
+    // Add suppression for Container Insight (V1 - Deprecated) not being Enabled while Container Insight V2 is Enabled with Enhanced
+    NagSuppressions.addResourceSuppressions(this.cluster, [
+      {
+        id: "AwsSolutions-ECS4",
+        reason:
+          "Container Insights V2 is Enabled with Enhanced capabilities, the Nag finding is about Container Insights (V1) which is deprecated",
+      },
+    ]);
+
     // Create context parameter for optional certificate ARN and custom domain
     const certificateArn = this.node.tryGetContext("certificateArn");
     const customDomain = this.node.tryGetContext("customDomain");

--- a/source/lib/stacks/mcp-server-stack.ts
+++ b/source/lib/stacks/mcp-server-stack.ts
@@ -29,6 +29,7 @@ export interface MCPServerStackProps extends cdk.StackProps {
   cognitoUserPool: cognito.UserPool;
   userPoolClientId: string;
   userPoolClientSecret: cdk.SecretValue;
+  domainSuffix: string;
 }
 
 /**
@@ -56,15 +57,16 @@ export class MCPServerStack extends cdk.Stack {
     // Create shared ECS cluster for all MCP servers
     this.cluster = new ecs.Cluster(this, "MCPCluster", {
       vpc: props.vpc,
+      //containerInsights: true,
       containerInsightsV2: ecs.ContainerInsights.ENHANCED
     });
 
-    // Add suppression for Container Insight (V1 - Deprecated) not being Enabled while Container Insight V2 is Enabled with Enhanced
+    // Add suppression for Container Insight (Deprecated) not be enabled while Container Insight V2 is enabled
     NagSuppressions.addResourceSuppressions(this.cluster, [
       {
         id: "AwsSolutions-ECS4",
         reason:
-          "Container Insights V2 is Enabled with Enhanced capabilities, the Nag finding is about Container Insights (V1) which is deprecated",
+          "Container Insights V2 is Enabled with Enhanced capabilities, the Nag findings is about Container Insights (v1) which is deprecated",
       },
     ]);
 
@@ -208,7 +210,7 @@ export class MCPServerStack extends cdk.Stack {
           AWS_REGION: this.region,
           COGNITO_USER_POOL_ID: props.cognitoUserPool.userPoolId,
           COGNITO_CLIENT_ID: props.userPoolClientId,
-          COGNITO_DOMAIN: `mcp-server-${props.resourceSuffix}`,
+          COGNITO_DOMAIN: `mcp-server-${props.domainSuffix}`,
           TOKEN_TABLE_NAME: tokenTable.tableName, // Pass the DynamoDB table name
         },
         secrets: {
@@ -247,7 +249,7 @@ export class MCPServerStack extends cdk.Stack {
           AWS_REGION: this.region,
           COGNITO_USER_POOL_ID: props.cognitoUserPool.userPoolId,
           COGNITO_CLIENT_ID: props.userPoolClientId,
-          COGNITO_DOMAIN: `mcp-server-${props.resourceSuffix}`,
+          COGNITO_DOMAIN: `mcp-server-${props.domainSuffix}`,
           TOKEN_TABLE_NAME: tokenTable.tableName, // Pass the DynamoDB table name
         },
         tokenTable: tokenTable, // Pass the table resource to grant permissions
@@ -281,7 +283,7 @@ export class MCPServerStack extends cdk.Stack {
           AWS_REGION: this.region,
           COGNITO_USER_POOL_ID: props.cognitoUserPool.userPoolId,
           COGNITO_CLIENT_ID: props.userPoolClientId,
-          COGNITO_DOMAIN: `mcp-server-${props.resourceSuffix}`,
+          COGNITO_DOMAIN: `mcp-server-${props.domainSuffix}`,
           TOKEN_TABLE_NAME: tokenTable.tableName, // Pass the DynamoDB table name
         },
         tokenTable: tokenTable, // Pass the table resource to grant permissions

--- a/source/lib/stacks/security-stack.ts
+++ b/source/lib/stacks/security-stack.ts
@@ -60,10 +60,12 @@ export class SecurityStack extends cdk.Stack {
 
     // Add domain for hosted UI
     // Use a simplified stack ID (removing non-compliant characters)
-    const domainPrefix = `mcp-server-${props.resourceSuffix
-      .substring(0, 8)
-      .toLowerCase()
-      .replace(/[^a-z0-9-]/g, "")}`;
+    const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+    let result = "";
+    for (let i = 0; i < 8; i++) {
+      result += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    const domainPrefix = `mcp-server-${result}`;
     this.userPool.addDomain("CognitoDomain", {
       cognitoDomain: {
         domainPrefix,

--- a/source/lib/stacks/security-stack.ts
+++ b/source/lib/stacks/security-stack.ts
@@ -17,6 +17,7 @@ export interface SecurityStackProps extends cdk.StackProps {
    * Resource suffix for unique naming
    */
   resourceSuffix: string;
+  domainSuffix: string
 }
 
 export class SecurityStack extends cdk.Stack {
@@ -59,13 +60,8 @@ export class SecurityStack extends cdk.Stack {
     });
 
     // Add domain for hosted UI
-    // Use a simplified stack ID (removing non-compliant characters)
-    const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
-    let result = "";
-    for (let i = 0; i < 8; i++) {
-      result += chars.charAt(Math.floor(Math.random() * chars.length));
-    }
-    const domainPrefix = `mcp-server-${result}`;
+    const domainPrefix = `mcp-server-${props.domainSuffix}`;
+    
     this.userPool.addDomain("CognitoDomain", {
       cognitoDomain: {
         domainPrefix,


### PR DESCRIPTION
*Issue*
Solves #2 

*Description of changes:*

Also when destroying an redeploying a Stack, the Cognito domain can take time to be released. As the Cognito Domain is statically linked to the Props suffix, the Stack redeployment will fails until it does. I have implemented a dynamic Cognito Domain definition that prevents this from happening. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
